### PR TITLE
save conversation state to sessionStorage

### DIFF
--- a/apps/test-site/src/App.tsx
+++ b/apps/test-site/src/App.tsx
@@ -29,7 +29,9 @@ function MyComponent(): JSX.Element {
   const [input, setInput] = useState("");
 
   useEffect(() => {
-    actions.getNextMessage();
+    if (messages.length === 0) {
+      actions.getNextMessage();
+    }
   }, [actions]);
 
   const onClick = useCallback(() => {

--- a/apps/test-site/src/App.tsx
+++ b/apps/test-site/src/App.tsx
@@ -32,7 +32,7 @@ function MyComponent(): JSX.Element {
     if (messages.length === 0) {
       actions.getNextMessage();
     }
-  }, [actions]);
+  }, [messages, actions]);
 
   const onClick = useCallback(() => {
     actions.getNextMessage(input);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18455,7 +18455,7 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
@@ -18768,6 +18768,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
+      }
+    },
+    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.2.0.tgz",
+      "integrity": "sha512-zqz9vqValCwikaaX2V2803WTgczj1PBf2FsJpqR1NN0NhyUhGJGJ5CJpBl34WAvWQK6+nvoy4SdLKN28MbqAyQ==",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.5",
+        "@yext/chat-core": "^0.2.0"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/packages/chat-headless/docs/chat-headless.chatheadless._constructor_.md
+++ b/packages/chat-headless/docs/chat-headless.chatheadless._constructor_.md
@@ -4,17 +4,18 @@
 
 ## ChatHeadless.(constructor)
 
-Constructs a new instance of the `ChatHeadless` class
+Constructs a new instance of the [ChatHeadless](./chat-headless.chatheadless.md) class.
 
 **Signature:**
 
 ```typescript
-constructor(config: ChatConfig);
+constructor(config: ChatConfig, saveToSessionStorage?: boolean);
 ```
 
 ## Parameters
 
 |  Parameter | Type | Description |
 |  --- | --- | --- |
-|  config | ChatConfig |  |
+|  config | ChatConfig | The configuration for the [ChatHeadless](./chat-headless.chatheadless.md) instance |
+|  saveToSessionStorage | boolean | _(Optional)_ Whether to save the instance's [ConversationState](./chat-headless.conversationstate.md) to session storage |
 

--- a/packages/chat-headless/docs/chat-headless.chatheadless._constructor_.md
+++ b/packages/chat-headless/docs/chat-headless.chatheadless._constructor_.md
@@ -17,5 +17,5 @@ constructor(config: ChatConfig, saveToSessionStorage?: boolean);
 |  Parameter | Type | Description |
 |  --- | --- | --- |
 |  config | ChatConfig | The configuration for the [ChatHeadless](./chat-headless.chatheadless.md) instance |
-|  saveToSessionStorage | boolean | _(Optional)_ Whether to save the instance's [ConversationState](./chat-headless.conversationstate.md) to session storage |
+|  saveToSessionStorage | boolean | _(Optional)_ Whether to save the instance's [ConversationState](./chat-headless.conversationstate.md) to session storage. Defaults to true. |
 

--- a/packages/chat-headless/docs/chat-headless.chatheadless.md
+++ b/packages/chat-headless/docs/chat-headless.chatheadless.md
@@ -16,7 +16,7 @@ export declare class ChatHeadless
 
 |  Constructor | Modifiers | Description |
 |  --- | --- | --- |
-|  [(constructor)(config)](./chat-headless.chatheadless._constructor_.md) |  | Constructs a new instance of the <code>ChatHeadless</code> class |
+|  [(constructor)(config, saveToSessionStorage)](./chat-headless.chatheadless._constructor_.md) |  | Constructs a new instance of the [ChatHeadless](./chat-headless.chatheadless.md) class. |
 
 ## Properties
 

--- a/packages/chat-headless/etc/chat-headless.api.md
+++ b/packages/chat-headless/etc/chat-headless.api.md
@@ -17,7 +17,7 @@ export { ChatConfig }
 
 // @public
 export class ChatHeadless {
-    constructor(config: ChatConfig);
+    constructor(config: ChatConfig, saveToSessionStorage?: boolean);
     addListener<T>(listener: StateListener<T>): Unsubscribe;
     getNextMessage(text?: string, source?: MessageSource): Promise<MessageResponse>;
     restartConversation(): void;

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A library for powering UI components for Yext Chat integrations",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -36,7 +36,7 @@ export class ChatHeadless {
    * @public
    *
    * @param config - The configuration for the {@link ChatHeadless} instance
-   * @param saveToSessionStorage - Whether to save the instance's {@link ConversationState} to session storage
+   * @param saveToSessionStorage - Whether to save the instance's {@link ConversationState} to session storage. Defaults to true.
    */
   constructor(config: ChatConfig, saveToSessionStorage = true) {
     this.chatCore = new ChatCore(config);
@@ -51,7 +51,7 @@ export class ChatHeadless {
         callback: () =>
           sessionStorage.setItem(
             STATE_SESSION_STORAGE_KEY,
-            JSON.stringify(this.stateManager.getState().conversation)
+            JSON.stringify(this.state.conversation)
           ),
       });
     }

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -48,10 +48,11 @@ export class ChatHeadless {
       });
       this.addListener({
         valueAccessor: (s) => s.conversation,
-        callback: () => sessionStorage.setItem(
+        callback: () =>
+          sessionStorage.setItem(
             STATE_SESSION_STORAGE_KEY,
-            JSON.stringify(this.stateManager.getState().conversation),
-        ),
+            JSON.stringify(this.stateManager.getState().conversation)
+          ),
       });
     }
   }

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -9,10 +9,12 @@ import {
 import { State } from "./models/state";
 import { ReduxStateManager } from "./ReduxStateManager";
 import {
+  loadSessionState,
   setConversationId,
   setIsLoading,
   setMessageNotes,
-  setMessages, STATE_SESSION_STORAGE_KEY,
+  setMessages,
+  STATE_SESSION_STORAGE_KEY,
 } from "./slices/conversation";
 import { Store, Unsubscribe } from "@reduxjs/toolkit";
 import { StateListener } from "./models";
@@ -28,15 +30,29 @@ export class ChatHeadless {
   private chatCore: ChatCore;
   private stateManager: ReduxStateManager;
 
-  constructor(config: ChatConfig) {
+  /**
+   * Constructs a new instance of the {@link ChatHeadless} class.
+   *
+   * @public
+   *
+   * @param config - The configuration for the {@link ChatHeadless} instance
+   * @param saveToSessionStorage - Whether to save the instance's {@link ConversationState} to session storage
+   */
+  constructor(config: ChatConfig, saveToSessionStorage = true) {
     this.chatCore = new ChatCore(config);
     this.stateManager = new ReduxStateManager();
-    this.stateManager.getStore().subscribe(() => {
-      sessionStorage.setItem(
-        STATE_SESSION_STORAGE_KEY,
-        JSON.stringify(this.stateManager.getState().conversation)
-      );
-    });
+    if (saveToSessionStorage) {
+      this.setState({
+        ...this.state,
+        conversation: loadSessionState(),
+      });
+      this.stateManager.getStore().subscribe(() => {
+        sessionStorage.setItem(
+          STATE_SESSION_STORAGE_KEY,
+          JSON.stringify(this.stateManager.getState().conversation)
+        );
+      });
+    }
   }
 
   /**

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -12,7 +12,7 @@ import {
   setConversationId,
   setIsLoading,
   setMessageNotes,
-  setMessages,
+  setMessages, STATE_SESSION_STORAGE_KEY,
 } from "./slices/conversation";
 import { Store, Unsubscribe } from "@reduxjs/toolkit";
 import { StateListener } from "./models";
@@ -31,6 +31,12 @@ export class ChatHeadless {
   constructor(config: ChatConfig) {
     this.chatCore = new ChatCore(config);
     this.stateManager = new ReduxStateManager();
+    this.stateManager.getStore().subscribe(() => {
+      sessionStorage.setItem(
+        STATE_SESSION_STORAGE_KEY,
+        JSON.stringify(this.stateManager.getState().conversation)
+      );
+    });
   }
 
   /**

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -46,11 +46,12 @@ export class ChatHeadless {
         ...this.state,
         conversation: loadSessionState(),
       });
-      this.stateManager.getStore().subscribe(() => {
-        sessionStorage.setItem(
-          STATE_SESSION_STORAGE_KEY,
-          JSON.stringify(this.stateManager.getState().conversation)
-        );
+      this.addListener({
+        valueAccessor: (s) => s.conversation,
+        callback: () => sessionStorage.setItem(
+            STATE_SESSION_STORAGE_KEY,
+            JSON.stringify(this.stateManager.getState().conversation),
+        ),
       });
     }
   }

--- a/packages/chat-headless/src/slices/conversation.ts
+++ b/packages/chat-headless/src/slices/conversation.ts
@@ -15,12 +15,12 @@ export const initialState: ConversationState = {
 export const loadSessionState = (): ConversationState => {
   if (!sessionStorage) {
     console.warn(
-        "Session storage is not available. State will not be persisted across page refreshes."
+      "Session storage is not available. State will not be persisted across page refreshes."
     );
     return initialState;
   }
-  const savedState = sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)
-  return savedState ? JSON.parse(savedState) : initialState
+  const savedState = sessionStorage.getItem(STATE_SESSION_STORAGE_KEY);
+  return savedState ? JSON.parse(savedState) : initialState;
 };
 
 /**

--- a/packages/chat-headless/src/slices/conversation.ts
+++ b/packages/chat-headless/src/slices/conversation.ts
@@ -2,7 +2,11 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ConversationState } from "../models/slices/conversation";
 import { Message, MessageNotes } from "@yext/chat-core";
 
-export const initialState: ConversationState = {
+export const STATE_SESSION_STORAGE_KEY : string = "conversationState";
+export const initialState: ConversationState =
+    sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)
+    ? JSON.parse(sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)!)
+    : {
   messages: [],
   isLoading: false,
 };

--- a/packages/chat-headless/src/slices/conversation.ts
+++ b/packages/chat-headless/src/slices/conversation.ts
@@ -13,14 +13,14 @@ export const initialState: ConversationState = {
  * Loads the {@link ConversationState} from session storage.
  */
 export const loadSessionState = (): ConversationState => {
-  if (sessionStorage?.getItem(STATE_SESSION_STORAGE_KEY)) {
-    return JSON.parse(sessionStorage?.getItem(STATE_SESSION_STORAGE_KEY) ?? "");
-  } else if (!sessionStorage) {
+  if (!sessionStorage) {
     console.warn(
-      "Session storage is not available. State will not be persisted across page refreshes."
+        "Session storage is not available. State will not be persisted across page refreshes."
     );
+    return initialState;
   }
-  return initialState;
+  const savedState = sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)
+  return savedState ? JSON.parse(savedState) : initialState
 };
 
 /**

--- a/packages/chat-headless/src/slices/conversation.ts
+++ b/packages/chat-headless/src/slices/conversation.ts
@@ -2,13 +2,25 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ConversationState } from "../models/slices/conversation";
 import { Message, MessageNotes } from "@yext/chat-core";
 
-export const STATE_SESSION_STORAGE_KEY : string = "conversationState";
-export const initialState: ConversationState =
-    sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)
-    ? JSON.parse(sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)!)
-    : {
+export const STATE_SESSION_STORAGE_KEY = "yext_chat_conversation_state";
+
+export const initialState: ConversationState = {
   messages: [],
   isLoading: false,
+};
+
+/**
+ * Loads the {@link ConversationState} from session storage.
+ */
+export const loadSessionState = (): ConversationState => {
+  if (sessionStorage?.getItem(STATE_SESSION_STORAGE_KEY)) {
+    return JSON.parse(sessionStorage?.getItem(STATE_SESSION_STORAGE_KEY) ?? "");
+  } else if (!sessionStorage) {
+    console.warn(
+      "Session storage is not available. State will not be persisted across page refreshes."
+    );
+  }
+  return initialState;
 };
 
 /**

--- a/packages/chat-headless/tests/chatheadless.test.ts
+++ b/packages/chat-headless/tests/chatheadless.test.ts
@@ -368,8 +368,12 @@ describe("loadSessionState works as expected", () => {
       JSON.stringify(expectedState)
     );
     const chatHeadless = new ChatHeadless(config);
+    chatHeadless.setState({
+      ...chatHeadless.state,
+      meta: mockedMetaState,
+    });
 
-    expect(chatHeadless.state).toEqual({ conversation: expectedState });
+    expect(chatHeadless.state).toEqual({ conversation: expectedState, meta: mockedMetaState });
   });
 
   it("does not persist or load state when toggle is off", () => {
@@ -378,7 +382,11 @@ describe("loadSessionState works as expected", () => {
       JSON.stringify(expectedState)
     );
     const chatHeadless = new ChatHeadless(config, false);
-    expect(chatHeadless.state).toEqual({ conversation: initialState });
+    chatHeadless.setState({
+      ...chatHeadless.state,
+      meta: mockedMetaState,
+    });
+    expect(chatHeadless.state).toEqual({ conversation: initialState, meta: mockedMetaState });
     const modifiedMessages = [
       ...expectedState.messages,
       {

--- a/packages/chat-headless/tests/chatheadless.test.ts
+++ b/packages/chat-headless/tests/chatheadless.test.ts
@@ -164,7 +164,7 @@ describe("Chat API methods work as expected", () => {
   };
 
   it("getNextMessage works as expected", async () => {
-    const chatHeadless = new ChatHeadless(config);
+    const chatHeadless = new ChatHeadless(config, false);
     chatHeadless.setState({
       conversation: initialState,
       meta: mockedMetaState,
@@ -211,7 +211,7 @@ describe("Chat API methods work as expected", () => {
   it("updates loading status and throw error when an API request returns an error", async () => {
     const errorMessage =
       "Chat API error: FATAL_ERROR: Invalid API Key. (code: 1)";
-    const chatHeadless = new ChatHeadless(config);
+    const chatHeadless = new ChatHeadless(config, false);
     const coreGetNextMessageSpy = jest
       .spyOn(ChatCore.prototype, "getNextMessage")
       .mockRejectedValue(errorMessage);
@@ -235,7 +235,7 @@ describe("Chat API methods work as expected", () => {
   });
 
   it("sends message array as is for initial message from bot", async () => {
-    const chatHeadless = new ChatHeadless(config);
+    const chatHeadless = new ChatHeadless(config, false);
     expect(chatHeadless.state.conversation.messages).toEqual([]);
 
     const coreGetNextMessageSpy = jest

--- a/packages/chat-headless/tests/chatheadless.test.ts
+++ b/packages/chat-headless/tests/chatheadless.test.ts
@@ -1,5 +1,6 @@
 import {
   ChatHeadless,
+  ConversationState,
   Message,
   MessageNotes,
   MessageSource,
@@ -348,7 +349,7 @@ it("restartConversation works as expected", () => {
 });
 
 describe("loadSessionState works as expected", () => {
-  const expectedState = {
+  const expectedState: ConversationState = {
     conversationId: "dummy-id",
     messages: [
       {
@@ -368,12 +369,10 @@ describe("loadSessionState works as expected", () => {
       JSON.stringify(expectedState)
     );
     const chatHeadless = new ChatHeadless(config);
-    chatHeadless.setState({
-      ...chatHeadless.state,
-      meta: mockedMetaState,
+    expect(chatHeadless.state).toEqual({
+      conversation: expectedState,
+      meta: {},
     });
-
-    expect(chatHeadless.state).toEqual({ conversation: expectedState, meta: mockedMetaState });
   });
 
   it("does not persist or load state when toggle is off", () => {
@@ -382,11 +381,10 @@ describe("loadSessionState works as expected", () => {
       JSON.stringify(expectedState)
     );
     const chatHeadless = new ChatHeadless(config, false);
-    chatHeadless.setState({
-      ...chatHeadless.state,
-      meta: mockedMetaState,
+    expect(chatHeadless.state).toEqual({
+      conversation: initialState,
+      meta: {},
     });
-    expect(chatHeadless.state).toEqual({ conversation: initialState, meta: mockedMetaState });
     const modifiedMessages = [
       ...expectedState.messages,
       {


### PR DESCRIPTION
adds logic in the initial state and ChatHeadless constructor to save/load from session storage. Also adds a minor adjustment to the test app so that it doesn't always send a request on load.

J=CLIP-113
TEST=manual

Ran test app, saw state saved in session storage. Refreshed page, conversation persists.