### PR TITLE
support baseEventPayload field in analyticsConfig (for internalUser)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4772,9 +4772,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yext/analytics": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.0.tgz",
-      "integrity": "sha512-0HIQlBN5d4+IHLYmAFr8eL/yje7+RcP0HuvVFUMnyQybvdyf5qiL3+DTS+IV7BiUFJBkZDmuVeQnTPd5tB9TiA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.1.tgz",
+      "integrity": "sha512-Demn/wLWZ8K95R/Klq+DYTpKt/vzNAH4BY1Nkl2lSqrc4ICArxK9feK8NCxSUM+ol15yiL2tBAfXrIpmRZ/pEQ==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "ulid": "^2.3.0"
@@ -18472,11 +18472,11 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.0",
+        "@yext/analytics": "^0.6.1",
         "@yext/chat-core": "^0.5.3"
       },
       "devDependencies": {

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -64,7 +64,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.0
+ - @yext/analytics@0.6.1
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless/docs/chat-headless.headlessconfig.analyticsconfig.md
+++ b/packages/chat-headless/docs/chat-headless.headlessconfig.analyticsconfig.md
@@ -4,10 +4,12 @@
 
 ## HeadlessConfig.analyticsConfig property
 
-Configurations for Chat analytics
+Configurations for Chat analytics.
 
 **Signature:**
 
 ```typescript
-analyticsConfig?: Omit<ChatAnalyticsConfig, "apiKey" | "env" | "region">;
+analyticsConfig?: Omit<ChatAnalyticsConfig, "apiKey" | "env" | "region"> & {
+        baseEventPayload?: DeepPartial<ChatEventPayLoad>;
+    };
 ```

--- a/packages/chat-headless/docs/chat-headless.headlessconfig.md
+++ b/packages/chat-headless/docs/chat-headless.headlessconfig.md
@@ -17,6 +17,6 @@ export interface HeadlessConfig extends ChatConfig
 
 |  Property | Modifiers | Type | Description |
 |  --- | --- | --- | --- |
-|  [analyticsConfig?](./chat-headless.headlessconfig.analyticsconfig.md) |  | Omit&lt;ChatAnalyticsConfig, "apiKey" \| "env" \| "region"&gt; | _(Optional)_ Configurations for Chat analytics |
+|  [analyticsConfig?](./chat-headless.headlessconfig.analyticsconfig.md) |  | Omit&lt;ChatAnalyticsConfig, "apiKey" \| "env" \| "region"&gt; &amp; { baseEventPayload?: DeepPartial&lt;ChatEventPayLoad&gt;; } | _(Optional)_ Configurations for Chat analytics. |
 |  [saveToSessionStorage?](./chat-headless.headlessconfig.savetosessionstorage.md) |  | boolean | _(Optional)_ Whether to save the instance's [ConversationState](./chat-headless.conversationstate.md) to session storage. Defaults to true. |
 

--- a/packages/chat-headless/etc/chat-headless.api.md
+++ b/packages/chat-headless/etc/chat-headless.api.md
@@ -65,7 +65,9 @@ export { Environment }
 
 // @public
 export interface HeadlessConfig extends ChatConfig {
-    analyticsConfig?: Omit<ChatAnalyticsConfig, "apiKey" | "env" | "region">;
+    analyticsConfig?: Omit<ChatAnalyticsConfig, "apiKey" | "env" | "region"> & {
+        baseEventPayload?: DeepPartial<ChatEventPayLoad>;
+    };
     saveToSessionStorage?: boolean;
 }
 

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A library for powering UI components for Yext Chat integrations",
   "main": "./dist/commonjs/index.js",
   "module": "./dist/esm/index.js",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/analytics": "^0.6.0",
+    "@yext/analytics": "^0.6.1",
     "@yext/chat-core": "^0.5.3"
   },
   "devDependencies": {

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -140,9 +140,11 @@ export class ChatHeadless {
       await this.chatAnalyticsService.report({
         timestamp: new Date().toISOString(),
         pageUrl: window?.location.href,
+        ...this.config.analyticsConfig?.baseEventPayload,
         ...eventPayload,
         chat: {
           ...chatProps,
+          ...this.config.analyticsConfig?.baseEventPayload?.chat,
           ...eventPayload.chat,
         },
       });

--- a/packages/chat-headless/src/models/HeadlessConfig.ts
+++ b/packages/chat-headless/src/models/HeadlessConfig.ts
@@ -1,4 +1,5 @@
-import { ChatAnalyticsConfig } from "@yext/analytics";
+import { DeepPartial } from "@reduxjs/toolkit";
+import { ChatAnalyticsConfig, ChatEventPayLoad } from "@yext/analytics";
 import { ChatConfig } from "@yext/chat-core";
 
 /**
@@ -9,6 +10,9 @@ import { ChatConfig } from "@yext/chat-core";
 export interface HeadlessConfig extends ChatConfig {
   /** Whether to save the instance's {@link ConversationState} to session storage. Defaults to true. */
   saveToSessionStorage?: boolean;
-  /** Configurations for Chat analytics */
-  analyticsConfig?: Omit<ChatAnalyticsConfig, "apiKey" | "env" | "region">;
+  /** Configurations for Chat analytics. */
+  analyticsConfig?: Omit<ChatAnalyticsConfig, "apiKey" | "env" | "region"> & {
+    /** Base payload to include for requests to the Analytics Events API. */
+    baseEventPayload?: DeepPartial<ChatEventPayLoad>;
+  };
 }


### PR DESCRIPTION
this PR updated analytics package version to include the newly added `internalUser` field in `EventPayload`. Also updated `HeadlessConfig` to accept a `baseEventPayload` in its analytics config, which will be included in subsequent reports by default and can be overridden by the event's specific payload pass through by user in `report()`.

J=CLIP-328
TEST=manual&auto

see that jest tests passed
see that having `internalUser: true` in the config result in it being included in subsequent event reports's payload
<img width="542" alt="Screenshot 2023-07-06 at 10 16 03 AM" src="https://github.com/yext/chat-headless/assets/36055303/0fc925f9-336f-4e00-86f0-614fd6ff0e35">
