### PR TITLE
extract headless and core version for clientSdk

### DIFF
--- a/apps/test-site/src/App.tsx
+++ b/apps/test-site/src/App.tsx
@@ -16,6 +16,9 @@ const config: HeadlessConfig = {
   },
   analyticsConfig: {
     endpoint: "https://www.dev.us.yextevents.com/accounts/me/events",
+    baseEventPayload: {
+      internalUser: true,
+    },
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18472,7 +18472,7 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",

--- a/packages/chat-headless/api-extractor.json
+++ b/packages/chat-headless/api-extractor.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "<projectFolder>/dist/esm/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/esm/src/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A library for powering UI components for Yext Chat integrations",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -2,9 +2,9 @@
   "name": "@yext/chat-headless",
   "version": "0.5.2",
   "description": "A library for powering UI components for Yext Chat integrations",
-  "main": "./dist/commonjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "main": "./dist/commonjs/src/index.js",
+  "module": "./dist/esm/src/index.js",
+  "types": "./dist/esm/src/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "chat",

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -27,6 +27,7 @@ import {
   ChatAnalyticsService,
   ChatEventPayLoad,
 } from "@yext/analytics";
+import { getClientSdk } from "./utils/clientSdk";
 
 /**
  * Provides the functionality for interacting with a Chat Bot
@@ -136,15 +137,20 @@ export class ChatHeadless {
       botId: this.config.botId,
       conversationId: this.state.conversation.conversationId,
     };
+    const baseEventPayload = this.config.analyticsConfig?.baseEventPayload;
     try {
       await this.chatAnalyticsService.report({
         timestamp: new Date().toISOString(),
         pageUrl: window?.location.href,
-        ...this.config.analyticsConfig?.baseEventPayload,
+        ...baseEventPayload,
         ...eventPayload,
+        clientSdk: getClientSdk({
+          ...baseEventPayload?.clientSdk,
+          ...eventPayload.clientSdk,
+        }),
         chat: {
           ...chatProps,
-          ...this.config.analyticsConfig?.baseEventPayload?.chat,
+          ...baseEventPayload?.chat,
           ...eventPayload.chat,
         },
       });

--- a/packages/chat-headless/src/utils/clientSdk.ts
+++ b/packages/chat-headless/src/utils/clientSdk.ts
@@ -1,0 +1,15 @@
+import { ChatEventPayLoad } from "@yext/analytics";
+import packageJson from "../../package.json";
+
+const { version } = packageJson;
+const coreVersion = packageJson.dependencies["@yext/chat-core"];
+
+export function getClientSdk(
+  additionalClientSdk?: ChatEventPayLoad["clientSdk"]
+): ChatEventPayLoad["clientSdk"] {
+  return {
+    ...additionalClientSdk,
+    CHAT_HEADLESS: version,
+    CHAT_CORE: coreVersion,
+  };
+}

--- a/packages/chat-headless/src/utils/clientSdk.ts
+++ b/packages/chat-headless/src/utils/clientSdk.ts
@@ -4,6 +4,12 @@ import packageJson from "../../package.json";
 const { version } = packageJson;
 const coreVersion = packageJson.dependencies["@yext/chat-core"];
 
+/**
+ * Creates new mapping for clientSdk by merging data from param additionalClientSdk
+ * with chat-headless's version and chat-core's version extracted from package.json
+ *
+ * @internal
+ */
 export function getClientSdk(
   additionalClientSdk?: ChatEventPayLoad["clientSdk"]
 ): ChatEventPayLoad["clientSdk"] {

--- a/packages/chat-headless/tests/chatheadless.analytics.test.ts
+++ b/packages/chat-headless/tests/chatheadless.analytics.test.ts
@@ -60,6 +60,9 @@ it("merges base payload with event specific payload (latter overrides)", () => {
         chat: {
           botId: "base-bot-id",
         },
+        clientSdk: {
+          CHAT_RANDOM_SDK: "0.0.0",
+        },
       },
     },
   });
@@ -78,6 +81,11 @@ it("merges base payload with event specific payload (latter overrides)", () => {
     timestamp: "mocked-time",
     chat: {
       botId: "event-specific-bot",
+    },
+    clientSdk: {
+      CHAT_CORE: expect.any(String),
+      CHAT_HEADLESS: expect.any(String),
+      CHAT_RANDOM_SDK: "0.0.0",
     },
   });
 });


### PR DESCRIPTION
extract chat-headless and chat-core version to pass into `clientSdk` field in analytic event's payload, including any additional `clientSdk` from `baseEventPayload` configured in headlessConfig.

Due to the import of `package.json` the structure of `dist/` is reformatted (now all previous files are inside src/ and package.json is included in the respective esm and commonjs folder). As such, the entry points needs to be updated to reflect this.

J=CLIP-309
TEST=manual&auto

see that jest tests passed
see in test-site that clientSdk is passed into the payload with the correct versions
<img width="709" alt="Screenshot 2023-07-07 at 9 57 41 AM" src="https://github.com/yext/chat-headless/assets/36055303/7f4d3509-5293-4a85-81a6-2655ebcadb92">
