### PR TITLE
pass chat-headless-react version to clientSdk field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18493,11 +18493,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.5.2",
+        "@yext/chat-headless": "^0.5.3",
         "react": "^18.2.0",
         "react-redux": "^8.0.5"
       },

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -170,7 +170,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following npm packages may be included in this product:
 
  - @yext/chat-core@0.5.3
- - @yext/chat-headless@0.5.2
+ - @yext/chat-headless@0.5.3
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/api-extractor.json
+++ b/packages/chat-headless-react/api-extractor.json
@@ -45,7 +45,7 @@
    *
    * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
    */
-  "mainEntryPointFilePath": "<projectFolder>/dist/esm/index.d.ts",
+  "mainEntryPointFilePath": "<projectFolder>/dist/esm/src/index.d.ts",
 
   /**
    * A list of NPM package names whose exports should be treated as part of this package.

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "the official React UI Bindings layer for Chat Headless",
-  "main": "./dist/commonjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "main": "./dist/commonjs/src/index.js",
+  "module": "./dist/esm/src/index.js",
+  "types": "./dist/esm/src/index.d.ts",
   "sideEffects": false,
   "keywords": [
     "chat",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.5.2",
+    "@yext/chat-headless": "^0.5.3",
     "react": "^18.2.0",
     "react-redux": "^8.0.5"
   },

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -2,6 +2,7 @@ import { ChatHeadless, HeadlessConfig } from "@yext/chat-headless";
 import { PropsWithChildren, useMemo } from "react";
 import { Provider } from "react-redux";
 import { ChatHeadlessContext } from "./ChatHeadlessContext";
+import { updateClientSdk } from "./utils/clientSdk";
 
 /**
  * Props for {@link ChatHeadlessProvider}
@@ -24,7 +25,10 @@ export function ChatHeadlessProvider(
   props: ChatHeadlessProviderProps
 ): JSX.Element {
   const { children, config } = props;
-  const headless = useMemo(() => new ChatHeadless(config), [config]);
+  const headless = useMemo(
+    () => new ChatHeadless(updateClientSdk(config)),
+    [config]
+  );
 
   return (
     <ChatHeadlessContext.Provider value={headless}>

--- a/packages/chat-headless-react/src/utils/clientSdk.ts
+++ b/packages/chat-headless-react/src/utils/clientSdk.ts
@@ -1,0 +1,25 @@
+import { HeadlessConfig } from "@yext/chat-headless";
+import packageJson from "../../package.json";
+const { version } = packageJson;
+
+/**
+ * Appends chat-headless-react's package version to the
+ * config's analytics "clientSdk" field.
+ *
+ * @internal
+ */
+export function updateClientSdk(config: HeadlessConfig): HeadlessConfig {
+  return {
+    ...config,
+    analyticsConfig: {
+      ...config.analyticsConfig,
+      baseEventPayload: {
+        ...config.analyticsConfig?.baseEventPayload,
+        clientSdk: {
+          ...config.analyticsConfig?.baseEventPayload?.clientSdk,
+          CHAT_HEADLESS_REACT: version,
+        },
+      },
+    },
+  };
+}

--- a/packages/chat-headless-react/tests/clientSdk.test.ts
+++ b/packages/chat-headless-react/tests/clientSdk.test.ts
@@ -1,0 +1,21 @@
+import { HeadlessConfig } from "@yext/chat-headless";
+import { updateClientSdk } from "../src/utils/clientSdk";
+
+it("appends lib version to clientSdk", () => {
+  const actualConfig = updateClientSdk({
+    apiKey: "my-api-key",
+    botId: "bot-bot-id",
+  });
+  const expectedConfig: HeadlessConfig = {
+    apiKey: "my-api-key",
+    botId: "bot-bot-id",
+    analyticsConfig: {
+      baseEventPayload: {
+        clientSdk: {
+          CHAT_HEADLESS_REACT: expect.any(String),
+        },
+      },
+    },
+  };
+  expect(actualConfig).toEqual(expectedConfig);
+});


### PR DESCRIPTION
extract chat-headless-react version to pass into `clientSdk` field in analytic event's payload

Due to the import of `package.json` the structure of `dist/` is reformatted (now all previous files are inside src/ and package.json is included in the respective esm and commonjs folder). As such, the entry points needs to be updated to reflect this.

J=CLIP-309
TEST=manual&auto

see that jest tests passed
see in test-site that clientSdk is passed into the payload with the correct versions (e.g. include the new CHAT_HEADLESS_REACT in addition to CHAT_HEADLESS and CHAT_CORE)

<img width="701" alt="Screenshot 2023-07-07 at 12 48 22 PM" src="https://github.com/yext/chat-headless/assets/36055303/4caefa1c-6f80-4fab-a54a-2eaff8968a6b">
