### PR TITLE
expose internal function addClientSdk for component lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18472,7 +18472,7 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",

--- a/packages/chat-headless/etc/chat-headless.api.md
+++ b/packages/chat-headless/etc/chat-headless.api.md
@@ -32,6 +32,8 @@ export { ChatConfig }
 // @public
 export class ChatHeadless {
     constructor(config: HeadlessConfig);
+    // @internal
+    addClientSdk(additionalClientSdk: Record<string, string>): void;
     addListener<T>(listener: StateListener<T>): Unsubscribe;
     addMessage(message: Message): void;
     getNextMessage(text?: string, source?: MessageSource): Promise<MessageResponse | undefined>;

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A library for powering UI components for Yext Chat integrations",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -115,6 +115,28 @@ export class ChatHeadless {
   }
 
   /**
+   * Adds additional client SDKs to the base event payload for Yext Analytics API.
+   *
+   * @remarks
+   * This is intended for internal usage in the Yext Chat related packages only.
+   *
+   * @internal
+   */
+  addClientSdk(additionalClientSdk: Record<string, string>) {
+    const { analyticsConfig } = this.config;
+    this.config.analyticsConfig = {
+      ...analyticsConfig,
+      baseEventPayload: {
+        ...analyticsConfig?.baseEventPayload,
+        clientSdk: {
+          ...analyticsConfig?.baseEventPayload?.clientSdk,
+          ...additionalClientSdk,
+        },
+      },
+    };
+  }
+
+  /**
    * Send Chat related analytics event to Yext Analytics API.
    *
    * @remarks

--- a/packages/chat-headless/tests/chatheadless.analytics.test.ts
+++ b/packages/chat-headless/tests/chatheadless.analytics.test.ts
@@ -89,3 +89,38 @@ it("merges base payload with event specific payload (latter overrides)", () => {
     },
   });
 });
+
+it("addClientSdk works as expected", () => {
+  jest.spyOn(Date.prototype, "toISOString").mockReturnValue("mocked-time");
+  const reportSpy = jest.fn();
+  jest.spyOn(AnalyticsLib, "provideChatAnalytics").mockImplementation(() => ({
+    report: reportSpy,
+  }));
+  const headless = new ChatHeadless({
+    ...config,
+    analyticsConfig: {
+      baseEventPayload: {
+        clientSdk: {
+          CHAT_RANDOM_SDK: "0.0.0",
+        },
+      },
+    },
+  });
+  headless.addClientSdk({
+    CHAT_NEW_SDK: "1.1.1",
+  });
+  headless.report({
+    action: "CHAT_LINK_CLICK",
+  });
+  expect(reportSpy).toBeCalledTimes(1);
+  expect(reportSpy).toBeCalledWith(
+    expect.objectContaining({
+      clientSdk: expect.objectContaining({
+        CHAT_CORE: expect.any(String),
+        CHAT_HEADLESS: expect.any(String),
+        CHAT_RANDOM_SDK: "0.0.0",
+        CHAT_NEW_SDK: "1.1.1",
+      }),
+    })
+  );
+});


### PR DESCRIPTION
chat-ui-react currently does NOT have a way to provide its package version for the **internal reports** for CHAT_RESPONSE events in chat-headless lib -- unlike CHAT_LINK_CLICK, THUMBS_UP/DOWN, and CHAT_IMPRESSION where chat-ui-react is the one to invoke the report call and is able to pass in its package version.

This PR exposes an **internal** function `addClientSdk` for this purpose.

J=CLIP-309
TEST=auto