### PR TITLE
analytics ulidx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18501,12 +18501,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.5.5",
-        "react": "^18.2.0",
+        "@yext/chat-headless": "^0.5.6",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -18522,7 +18521,11 @@
         "babel-jest": "^29.5.0",
         "jest": "^29.5.0",
         "jest-environment-jsdom": "^29.5.0",
+        "react": "^18.2.0",
         "typescript": "^5.0.4"
+      },
+      "peerDependencies": {
+        "react": "^16.14 || ^17 || ^18"
       }
     },
     "packages/chat-headless-react/node_modules/@jest/console": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -95,8 +95,8 @@ MIT License
 The following npm packages may be included in this product:
 
  - @types/prop-types@15.7.5
- - @types/react-dom@18.2.6
- - @types/react@18.2.14
+ - @types/react-dom@18.2.7
+ - @types/react@18.2.15
  - @types/scheduler@0.16.3
  - @types/use-sync-external-store@0.0.3
 
@@ -128,7 +128,7 @@ MIT License
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.1
+ - @yext/analytics@0.6.2
 
 This package contains the following license and notice below:
 
@@ -170,7 +170,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following npm packages may be included in this product:
 
  - @yext/chat-core@0.5.3
- - @yext/chat-headless@0.5.5
+ - @yext/chat-headless@0.5.6
 
 These packages each contain the following license and notice below:
 
@@ -363,6 +363,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+-----------
+
+The following npm package may be included in this product:
+
+ - layerr@2.0.0
+
+This package contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020 Perry Mitchell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 -----------
 
@@ -594,13 +624,13 @@ This package contains the following license and notice below:
 
 The following npm package may be included in this product:
 
- - ulid@2.3.0
+ - ulidx@2.0.0
 
 This package contains the following license and notice below:
 
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2017 Alizain Feerasta
+Copyright (c) 2021 Perry Mitchell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",
@@ -39,11 +39,14 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.5.5",
-    "react": "^18.2.0",
+    "@yext/chat-headless": "^0.5.6",
     "react-redux": "^8.0.5"
   },
+  "peerDependencies": {
+    "react": "^16.14 || ^17 || ^18"
+  },
   "devDependencies": {
+    "react": "^18.2.0",
     "@babel/preset-env": "^7.21.5",
     "@babel/preset-react": "^7.18.6",
     "@babel/preset-typescript": "^7.21.5",


### PR DESCRIPTION
also update React dep to be peerDep instead, and let consumer of this lib should decide the React version they use (as long as it's compatible with the range listed)

this follows search-headless-react: https://github.com/yext/search-headless-react/blob/main/package.json#L74