### PR TITLE
headless: analytics support for referrerUrl and visitor

### DIFF
--- a/apps/test-site/src/App.tsx
+++ b/apps/test-site/src/App.tsx
@@ -77,6 +77,9 @@ function ChatComponent() {
   const onReport = useCallback(async () => {
     await actions.report({
       action: "CHAT_LINK_CLICK",
+      visitor: {
+        "test-id": "test-method",
+      },
     });
   }, [actions]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4772,9 +4772,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@yext/analytics": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.2.tgz",
-      "integrity": "sha512-ZdvQUSyQw/184wPtk8CJbZCRd30eU04qGIh60mt8QplvmQz5L/rNVbxl0HVEAV+QXXWDmt/lNxpCivGm7IZNnw==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@yext/analytics/-/analytics-0.6.3.tgz",
+      "integrity": "sha512-2fGbMaHl/OHQUxrCWGlh8vyCDr0CAOzJ0rq6pCqtSPVwmT7N+8eQmSYRkcNBBg8phA1BGsxbnMoxqKENesNOLg==",
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "ulidx": "^2.0.0"
@@ -18484,7 +18484,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.2",
+        "@yext/analytics": "^0.6.3",
         "@yext/chat-core": "^0.5.3"
       },
       "devDependencies": {

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -64,7 +64,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.2
+ - @yext/analytics@0.6.3
 
 This package contains the following license and notice below:
 
@@ -207,7 +207,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - layerr@2.0.0
+ - layerr@2.0.1
 
 This package contains the following license and notice below:
 
@@ -397,7 +397,7 @@ This package contains the following license and notice below:
 
 The following npm package may be included in this product:
 
- - ulidx@2.0.0
+ - ulidx@2.1.0
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/analytics": "^0.6.2",
+    "@yext/analytics": "^0.6.3",
     "@yext/chat-core": "^0.5.3"
   },
   "devDependencies": {

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -179,6 +179,7 @@ export class ChatHeadless {
       await this.chatAnalyticsService.report({
         timestamp: new Date().toISOString(),
         pageUrl: window?.location.href,
+        referrerUrl: window?.document.referrer,
         ...baseEventPayload,
         ...eventPayload,
         clientSdk: getClientSdk({

--- a/packages/chat-headless/tests/chatheadless.analytics.test.ts
+++ b/packages/chat-headless/tests/chatheadless.analytics.test.ts
@@ -57,6 +57,10 @@ it("merges base payload with event specific payload (latter overrides)", () => {
       baseEventPayload: {
         internalUser: true,
         pageUrl: "base-page",
+        referrerUrl: "referrer-page",
+        visitor: {
+          "some-id": "some-method",
+        },
         chat: {
           botId: "base-bot-id",
         },
@@ -76,9 +80,13 @@ it("merges base payload with event specific payload (latter overrides)", () => {
   expect(reportSpy).toBeCalledTimes(1);
   expect(reportSpy).toBeCalledWith({
     action: "CHAT_LINK_CLICK",
+    timestamp: "mocked-time",
     internalUser: true,
     pageUrl: "event-specific-page",
-    timestamp: "mocked-time",
+    referrerUrl: "referrer-page",
+    visitor: {
+      "some-id": "some-method",
+    },
     chat: {
       botId: "event-specific-bot",
     },


### PR DESCRIPTION
bump analytics package version to get support for referrerUrl and visitor field. Also add default value for `referrerUrl` when execute `report` function

J=CLIP-374
TEST=manual&auto

tested through test-site and see that both are present in the request's body.