### PR TITLE
guard empty string for urls in analytics payload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18480,7 +18480,7 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.5.7",
+      "version": "0.5.8",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "description": "A library for powering UI components for Yext Chat integrations",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",

--- a/packages/chat-headless/src/ChatHeadless.ts
+++ b/packages/chat-headless/src/ChatHeadless.ts
@@ -180,8 +180,8 @@ export class ChatHeadless {
     try {
       await this.chatAnalyticsService.report({
         timestamp: new Date().toISOString(),
-        pageUrl: window?.location.href,
-        referrerUrl: window?.document.referrer,
+        pageUrl: window?.location.href || undefined,
+        referrerUrl: window?.document.referrer || undefined,
         ...baseEventPayload,
         ...eventPayload,
         clientSdk: getClientSdk({


### PR DESCRIPTION
this PR guard empty string for the default values of pageUrl and referrerUrl to avoid this issue
![Screenshot 2023-08-01 at 3 03 43 PM](https://github.com/yext/chat-headless/assets/36055303/219f6650-d1d3-4415-9dee-b38077bde8a6)
