### PR TITLE
Chat-headless-react: Surface overridable instance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18501,11 +18501,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.5.8",
+        "@yext/chat-headless": "^0.6.0",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -18805,16 +18805,6 @@
       "integrity": "sha512-gWdNKO1ioK5cy25mjE/EXzZ5NK4Dh/cqqPMF9YFON4K3G0xj6+/gPj8mfyF8DRHb2BtkM0hC/0cRAQ3RnBfM2A==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
-      }
-    },
-    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.5.8.tgz",
-      "integrity": "sha512-cQvGpOdQwgTUVT+t8BGnTXqFLFSxLH4QvdkXEh02gbKkcKr4sh8/O43iJrc1Vq45DgaXOxEJhfCsA60RkybwUA==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.5.4"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18799,14 +18799,6 @@
         "@types/yargs-parser": "*"
       }
     },
-    "packages/chat-headless-react/node_modules/@yext/chat-core": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.5.5.tgz",
-      "integrity": "sha512-gWdNKO1ioK5cy25mjE/EXzZ5NK4Dh/cqqPMF9YFON4K3G0xj6+/gPj8mfyF8DRHb2BtkM0hC/0cRAQ3RnBfM2A==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5"
-      }
-    },
     "packages/chat-headless-react/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -169,8 +169,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following npm packages may be included in this product:
 
- - @yext/chat-core@0.5.5
- - @yext/chat-headless@0.5.8
+ - @yext/chat-core@0.6.1
+ - @yext/chat-headless@0.6.0
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/docs/chat-headless-react.chatheadlessprovider.md
+++ b/packages/chat-headless-react/docs/chat-headless-react.chatheadlessprovider.md
@@ -4,7 +4,7 @@
 
 ## ChatHeadlessProvider() function
 
-Instantiates a ChatHeadless instance for [ChatHeadlessContext](./chat-headless-react.chatheadlesscontext.md) and provide the context for all children components.
+Instantiates a ChatHeadless instance for [ChatHeadlessContext](./chat-headless-react.chatheadlesscontext.md) and provides the context to all children components.
 
 **Signature:**
 

--- a/packages/chat-headless-react/docs/chat-headless-react.md
+++ b/packages/chat-headless-react/docs/chat-headless-react.md
@@ -8,7 +8,7 @@
 
 |  Function | Description |
 |  --- | --- |
-|  [ChatHeadlessProvider(props)](./chat-headless-react.chatheadlessprovider.md) | Instantiates a ChatHeadless instance for [ChatHeadlessContext](./chat-headless-react.chatheadlesscontext.md) and provide the context for all children components. |
+|  [ChatHeadlessProvider(props)](./chat-headless-react.chatheadlessprovider.md) | Instantiates a ChatHeadless instance for [ChatHeadlessContext](./chat-headless-react.chatheadlesscontext.md) and provides the context to all children components. |
 |  [useChatActions()](./chat-headless-react.usechatactions.md) | A React hook that returns a ChatHeadless instance with setter methods to update state. |
 |  [useChatState(stateSelector)](./chat-headless-react.usechatstate.md) | A React hook that returns a Chat state in store as specified by the map function. |
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.5.8",
+    "@yext/chat-headless": "^0.6.0",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -49,7 +49,7 @@ export function ChatHeadlessProvider(
 /**
  * Props for {@link ChatHeadlessInstanceProvider}
  *
- * @public
+ * @internal
  */
 export type ChatHeadlessInstanceProviderProps = PropsWithChildren<{
   // Set this to true when using server-side rendering in conjunction with
@@ -63,7 +63,7 @@ export type ChatHeadlessInstanceProviderProps = PropsWithChildren<{
  * the context to all children components.
  * @param props - {@link ChatHeadlessInstanceProviderProps}
  *
- * @public
+ * @internal
  */
 export function ChatHeadlessInstanceProvider(
   props: ChatHeadlessInstanceProviderProps

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -14,8 +14,8 @@ export type ChatHeadlessProviderProps = PropsWithChildren<{
 }>;
 
 /**
- * Instantiates a ChatHeadless instance for {@link ChatHeadlessContext} and provide
- * the context for all children components.
+ * Instantiates a ChatHeadless instance for {@link ChatHeadlessContext} and provides
+ * the context to all children components.
  *
  * @param props - {@link ChatHeadlessProviderProps}
  *
@@ -25,10 +25,6 @@ export function ChatHeadlessProvider(
   props: ChatHeadlessProviderProps
 ): JSX.Element {
   const { children, config } = props;
-  // deferLoad is used with sessionStorage so that the children won't be
-  // immediately rendered and trigger the "load initial message" flow before
-  // the state can be loaded from session.
-  const [deferLoad, setDeferLoad] = useState(config.saveToSessionStorage);
 
   const headless = useMemo(() => {
     const configWithoutSession = { ...config, saveToSessionStorage: false };
@@ -36,16 +32,52 @@ export function ChatHeadlessProvider(
     return headless;
   }, [config]);
 
+  return (
+    <ChatHeadlessInstanceProvider
+      saveToSessionStorage={config.saveToSessionStorage}
+      headless={headless}
+    >
+      {children}
+    </ChatHeadlessInstanceProvider>
+  );
+}
+
+/**
+ * Props for {@link ChatHeadlessInstanceProvider}
+ *
+ * @public
+ */
+export type ChatHeadlessInstanceProviderProps = PropsWithChildren<{
+  saveToSessionStorage?: boolean;
+  headless: ChatHeadless;
+}>;
+
+/**
+ * Takes in a ChatHeadless instance for {@link ChatHeadlessContext} and provides
+ * the context to all children components.
+ * @param props - {@link ChatHeadlessInstanceProviderProps}
+ *
+ * @public
+ */
+export function ChatHeadlessInstanceProvider(
+  props: ChatHeadlessInstanceProviderProps
+): JSX.Element {
+  const { children, saveToSessionStorage, headless } = props;
+  // deferLoad is used with sessionStorage so that the children won't be
+  // immediately rendered and trigger the "load initial message" flow before
+  // the state can be loaded from session.
+  const [deferLoad, setDeferLoad] = useState(saveToSessionStorage);
+
   // sessionStorage is overridden here so that it is compatible with server-
   // side rendering, which cannot have browser api calls like session storage
   // outside of hooks.
   useEffect(() => {
-    if (!config.saveToSessionStorage || !headless) {
+    if (!saveToSessionStorage || !headless) {
       return;
     }
     headless.initSessionStorage();
     setDeferLoad(false);
-  }, [headless, config]);
+  }, [headless, saveToSessionStorage]);
 
   return (
     <ChatHeadlessContext.Provider value={headless}>

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -1,4 +1,8 @@
-import { ChatHeadless, HeadlessConfig } from "@yext/chat-headless";
+import {
+  provideChatHeadless,
+  ChatHeadless,
+  HeadlessConfig,
+} from "@yext/chat-headless";
 import { PropsWithChildren, useMemo, useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import { ChatHeadlessContext } from "./ChatHeadlessContext";
@@ -28,7 +32,7 @@ export function ChatHeadlessProvider(
 
   const headless = useMemo(() => {
     const configWithoutSession = { ...config, saveToSessionStorage: false };
-    const headless = new ChatHeadless(updateClientSdk(configWithoutSession));
+    const headless = provideChatHeadless(updateClientSdk(configWithoutSession));
     return headless;
   }, [config]);
 

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -38,7 +38,7 @@ export function ChatHeadlessProvider(
 
   return (
     <ChatHeadlessInstanceProvider
-      saveToSessionStorage={config.saveToSessionStorage}
+      deferRender={config.saveToSessionStorage}
       headless={headless}
     >
       {children}
@@ -52,7 +52,9 @@ export function ChatHeadlessProvider(
  * @public
  */
 export type ChatHeadlessInstanceProviderProps = PropsWithChildren<{
-  saveToSessionStorage?: boolean;
+  // Set this to true when using server-side rendering in conjunction with
+  // browser-specific APIs like session storage.
+  deferRender?: boolean;
   headless: ChatHeadless;
 }>;
 
@@ -66,22 +68,22 @@ export type ChatHeadlessInstanceProviderProps = PropsWithChildren<{
 export function ChatHeadlessInstanceProvider(
   props: ChatHeadlessInstanceProviderProps
 ): JSX.Element {
-  const { children, saveToSessionStorage, headless } = props;
-  // deferLoad is used with sessionStorage so that the children won't be
+  const { children, deferRender, headless } = props;
+  // deferLoad is typically used with sessionStorage so that the children won't be
   // immediately rendered and trigger the "load initial message" flow before
   // the state can be loaded from session.
-  const [deferLoad, setDeferLoad] = useState(saveToSessionStorage);
+  const [deferLoad, setDeferLoad] = useState(deferRender);
 
   // sessionStorage is overridden here so that it is compatible with server-
   // side rendering, which cannot have browser api calls like session storage
   // outside of hooks.
   useEffect(() => {
-    if (!saveToSessionStorage || !headless) {
+    if (!deferRender || !headless) {
       return;
     }
     headless.initSessionStorage();
     setDeferLoad(false);
-  }, [headless, saveToSessionStorage]);
+  }, [headless, deferRender]);
 
   return (
     <ChatHeadlessContext.Provider value={headless}>


### PR DESCRIPTION
Splits out ChatHeadlessProvider to create ChatHeadlessInstanceProvider, which allows users to pass through a _pre-defined_ ChatHeadless instance instead of the one which is created internally and cannot be hooked into from other functions