### PR TITLE
add type: module or type: commonjs to package.json

### DIFF
--- a/apps/test-site/craco.config.js
+++ b/apps/test-site/craco.config.js
@@ -1,0 +1,19 @@
+module.exports = {
+  webpack: {
+      configure: {
+          module: {
+              rules: [
+                  //This rule is to escape the error of requiring .mjs/.js extension due
+                  //to origin being strict ESM (package.json contains '"type": "module"')
+                  //https://webpack.js.org/configuration/module/#resolvefullyspecified
+                  {
+                      test: /\.m?js$/,
+                      resolve: {
+                          fullySpecified: false,
+                      },
+                  },
+              ],
+          },
+      },
+  },
+};

--- a/apps/test-site/package.json
+++ b/apps/test-site/package.json
@@ -14,10 +14,9 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "start": "craco start",
+    "build": "craco build",
+    "test": "craco test"
   },
   "browserslist": {
     "production": [
@@ -30,5 +29,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@craco/craco": "^7.1.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,33 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@craco/craco": "^7.1.0"
+      }
+    },
+    "apps/test-site/node_modules/@craco/craco": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@craco/craco/-/craco-7.1.0.tgz",
+      "integrity": "sha512-oRAcPIKYrfPXp9rSzlsDNeOaVtDiKhoyqSXUoqiK24jCkHr4T8m/a2f74yXIzCbIheoUWDOIfWZyRgFgT+cpqA==",
+      "dev": true,
+      "dependencies": {
+        "autoprefixer": "^10.4.12",
+        "cosmiconfig": "^7.0.1",
+        "cosmiconfig-typescript-loader": "^1.0.0",
+        "cross-spawn": "^7.0.3",
+        "lodash": "^4.17.21",
+        "semver": "^7.3.7",
+        "webpack-merge": "^5.8.0"
+      },
+      "bin": {
+        "craco": "dist/bin/craco.js"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "react-scripts": "^5.0.0"
       }
     },
     "apps/test-site/node_modules/@types/node": {
@@ -1832,6 +1859,28 @@
     "node_modules/@bcoe/v8-coverage": {
       "version": "0.2.3",
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@csstools/normalize.css": {
       "version": "12.0.0",
@@ -4113,6 +4162,30 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "devOptional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "devOptional": true
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "dev": true,
@@ -4882,7 +4955,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -5943,6 +6016,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "license": "MIT",
@@ -6160,6 +6247,31 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/cosmiconfig-typescript-loader": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-1.0.9.tgz",
+      "integrity": "sha512-tRuMRhxN4m1Y8hP9SNYfz7jRwt8lZdWxdjg/ohg5esKmsndJIn4yT96oJVcf5x0eA11taXl+sIp+ielu529k6g==",
+      "dev": true,
+      "dependencies": {
+        "cosmiconfig": "^7",
+        "ts-node": "^10.7.0"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "cosmiconfig": ">=7",
+        "typescript": ">=3"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "devOptional": true
     },
     "node_modules/cross-fetch": {
       "version": "3.1.6",
@@ -6730,6 +6842,15 @@
     "node_modules/didyoumean": {
       "version": "1.2.2",
       "license": "Apache-2.0"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.4.3",
@@ -9441,6 +9562,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "license": "MIT"
@@ -9604,6 +9737,15 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -13063,6 +13205,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "devOptional": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "license": "BSD-3-Clause",
@@ -16310,6 +16458,18 @@
       "version": "1.2.0",
       "license": "ISC"
     },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -17186,6 +17346,55 @@
       "version": "0.1.13",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "devOptional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "devOptional": true
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "license": "MIT",
@@ -17580,6 +17789,12 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "devOptional": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "8.1.1",
       "license": "ISC",
@@ -17926,6 +18141,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webpack-merge": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.9.0.tgz",
+      "integrity": "sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "license": "MIT",
@@ -18044,6 +18272,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+      "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
+      "dev": true
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -18440,6 +18674,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "devOptional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "license": "MIT",
@@ -18501,7 +18744,7 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @babel/runtime@7.22.10
+ - @babel/runtime@7.22.11
 
 This package contains the following license and notice below:
 
@@ -96,7 +96,7 @@ The following npm packages may be included in this product:
 
  - @types/prop-types@15.7.5
  - @types/react-dom@18.2.7
- - @types/react@18.2.20
+ - @types/react@18.2.21
  - @types/scheduler@0.16.3
  - @types/use-sync-external-store@0.0.3
 
@@ -128,7 +128,7 @@ MIT License
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.3
+ - @yext/analytics@0.6.4
 
 This package contains the following license and notice below:
 
@@ -428,7 +428,7 @@ THE SOFTWARE.
 
 The following npm package may be included in this product:
 
- - node-fetch@2.6.12
+ - node-fetch@2.7.0
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -25,8 +25,9 @@
     "tsc-esm": "tsc -p tsconfig.esm.json",
     "dev": "npm run tsc-esm -- --watch",
     "generate-notices": "../../generate-notices.sh",
+    "update-lib-package": "node ../../update-lib-package.js",
     "generate-docs": "api-extractor run --local --verbose && api-documenter markdown --input-folder temp --output-folder docs && rm -rf temp",
-    "build": "rm -rf dist/** && npm run tsc-esm && npm run tsc-cjs && npm run generate-docs && npm run generate-notices"
+    "build": "rm -rf dist/** && npm run tsc-esm && npm run tsc-cjs && npm run update-lib-package && npm run generate-docs && npm run generate-notices"
   },
   "repository": {
     "type": "git",

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @babel/runtime@7.22.10
+ - @babel/runtime@7.22.11
 
 This package contains the following license and notice below:
 
@@ -64,7 +64,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.3
+ - @yext/analytics@0.6.4
 
 This package contains the following license and notice below:
 
@@ -237,7 +237,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - node-fetch@2.6.12
+ - node-fetch@2.7.0
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -25,8 +25,9 @@
     "tsc-esm": "tsc -p tsconfig.esm.json",
     "dev": "npm run tsc-esm -- --watch",
     "generate-notices": "../../generate-notices.sh",
+    "update-lib-package": "node ../../update-lib-package.js",
     "generate-docs": "api-extractor run --local --verbose && api-documenter markdown --input-folder temp --output-folder docs && rm -rf temp",
-    "build": "rm -rf dist/** && npm run tsc-esm && npm run tsc-cjs && npm run generate-docs && npm run generate-notices"
+    "build": "rm -rf dist/** && npm run tsc-esm && npm run tsc-cjs && npm run update-lib-package && npm run generate-docs && npm run generate-notices"
   },
   "repository": {
     "type": "git",

--- a/update-lib-package.js
+++ b/update-lib-package.js
@@ -1,0 +1,36 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require('fs');
+
+const packagePathToType = {
+  "./dist/esm/package.json": "module",
+  "./dist/commonjs/package.json": "commonjs",
+}
+
+Object.entries(packagePathToType).forEach(([packageJsonPath, type]) => {
+  // Read the package.json file
+  fs.readFile(packageJsonPath, 'utf8', (err, data) => {
+    if (err) {
+      console.error(`Error reading package.json: ${err}`);
+      return;
+    }
+
+    try {
+      // Parse the package.json content
+      const packageJson = JSON.parse(data);
+
+      // Add "type: module" or "type: commonjs" to the package.json
+      packageJson.type = type;
+
+      // Write the updated package.json back to the file
+      fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8', (err) => {
+        if (err) {
+          console.error(`Error writing package.json: ${err}`);
+          return;
+        }
+        console.log(`Added "type: ${type}" to ${packageJsonPath}`);
+      });
+    } catch (err) {
+      console.error(`Error parsing package.json: ${err}`);
+    }
+  });
+})


### PR DESCRIPTION
this PR adds `type: module` or `type: commonjs` to package.json.

Also updated test-site to resolve the issue from adding this `type` field. see this PR for more details: https://github.com/yext/chat-ui-react/pull/37

J=CLIP-450
TEST=manual

see that the type field is in lib/esm and lib/commonjs for chat-headless and chat-headless-react. See that test-site still works as expected.
<img width="544" alt="Screenshot 2023-08-30 at 4 17 26 PM" src="https://github.com/yext/chat-headless/assets/36055303/c4470509-0407-43fb-851f-66e0531db85f">
