### PR TITLE
bump headless-react version for the type:module fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18744,11 +18744,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.5.10",
+      "version": "0.5.11",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.6.0",
+        "@yext/chat-headless": "^0.6.1",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -170,7 +170,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following npm packages may be included in this product:
 
  - @yext/chat-core@0.6.1
- - @yext/chat-headless@0.6.0
+ - @yext/chat-headless@0.6.1
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.js",
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.6.0",
+    "@yext/chat-headless": "^0.6.1",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
bump version for this update: https://github.com/yext/chat-headless/pull/36

J=CLIP-450
TEST=manual

see that test-site is still ok