### PR TITLE
bump headless-react version (v0.6.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4880,14 +4880,6 @@
         "ulidx": "^2.0.0"
       }
     },
-    "node_modules/@yext/chat-core": {
-      "version": "0.7.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.7.0-alpha.23.tgz",
-      "integrity": "sha512-51c2XSCLjTpnq5c6CvWovJTaMMlBPzKhCp0bIiHHbK9+v+zCei8/JhKTsA7bl2okx9ZbUV95OO1VQrHxtryahA==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5"
-      }
-    },
     "node_modules/@yext/chat-headless": {
       "resolved": "packages/chat-headless",
       "link": true
@@ -18736,7 +18728,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "0.7.0-alpha.38.2",
+        "@yext/chat-headless": "0.7.0",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -19031,16 +19023,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
-      }
-    },
-    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
-      "version": "0.7.0-alpha.38.2",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.7.0-alpha.38.2.tgz",
-      "integrity": "sha512-+0WvXz874i7mjFE/jsNuFzWohWg954zOIyTX+LzsV/Q+cJguEEnqn4KBPXVDu1BuQK9QWNFiCNk6k3MSIAGDyA==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "0.7.0-alpha.23"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -169,8 +169,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following npm packages may be included in this product:
 
- - @yext/chat-core@0.7.0-alpha.23
- - @yext/chat-headless@0.7.0-alpha.38.2
+ - @yext/chat-core@0.7.0
+ - @yext/chat-headless@0.7.0
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "0.7.0-alpha.38.2",
+    "@yext/chat-headless": "0.7.0",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
bump headless version in headless-react following changes from this PR: https://github.com/yext/chat-headless/pull/38

will release a new v0.6.0 version for headless-react

J=CLIP-556