### PR TITLE
ChatHeadless: store state in session storage by hostname and botId

### DIFF
--- a/generate-notices.sh
+++ b/generate-notices.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Because of the monorepo structure, license-check from generate-license-file lib is an unable
 # to properly parse all the relevant depedencies in the node_modules of a package. This script
 # will temporarily copy the target package outside of the packages/ to generate the

--- a/package-lock.json
+++ b/package-lock.json
@@ -18700,7 +18700,7 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
@@ -18728,7 +18728,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.7.1",
+        "@yext/chat-headless": "file:~/chat-headless/packages/chat-headless",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18728,7 +18728,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "file:~/chat-headless/packages/chat-headless",
+        "@yext/chat-headless": "^0.7.1",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @babel/runtime@7.23.5
+ - @babel/runtime@7.23.6
 
 This package contains the following license and notice below:
 
@@ -66,8 +66,8 @@ The following npm packages may be included in this product:
 
  - @types/hoist-non-react-statics@3.3.5
  - @types/prop-types@15.7.11
- - @types/react-dom@18.2.17
- - @types/react@18.2.42
+ - @types/react-dom@18.2.18
+ - @types/react@18.2.45
  - @types/scheduler@0.16.8
  - @types/use-sync-external-store@0.0.3
 
@@ -213,7 +213,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - csstype@3.1.2
+ - csstype@3.1.3
 
 This package contains the following license and notice below:
 
@@ -525,7 +525,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - regenerator-runtime@0.14.0
+ - regenerator-runtime@0.14.1
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless-react/tsconfig.json
+++ b/packages/chat-headless-react/tsconfig.json
@@ -12,12 +12,12 @@
     "sourceMap": true,
     /**
      * Use "react" instead of "react-jsx" to be compatible with lower React versions (e.g. 16)
-     * 
+     *
      * "react/jsx-runtime" have explicit "exports" field in React 18 but not in React 16/17 when
      * it was backported. This would require our SDK to provide two bundles, one for React 18 and
      * one for legacy versions that require us to define explicit paths
      * (https://github.com/facebook/react/issues/20235).
-     * 
+     *
      * by using "react", we avoid the syntactic sugar JSX and output code directly using "React.createElement"
      */
     "jsx": "react",

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -1,4 +1,7 @@
-The following NPM package may be included in this product:
+This file was generated with the generate-license-file npm package!
+https://www.npmjs.com/package/generate-license-file
+
+The following npm package may be included in this product:
 
  - @babel/runtime@7.23.6
 
@@ -29,7 +32,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - @reduxjs/toolkit@1.9.7
 
@@ -59,7 +62,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - @yext/analytics@0.6.5
 
@@ -100,7 +103,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - @yext/chat-core@0.7.0
 
@@ -142,7 +145,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - cross-fetch@3.1.8
 
@@ -172,7 +175,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - immer@9.0.21
 
@@ -202,7 +205,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - layerr@2.0.1
 
@@ -232,7 +235,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - node-fetch@2.7.0
 
@@ -262,7 +265,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - redux-thunk@2.4.2
 
@@ -292,7 +295,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - redux@4.2.1
 
@@ -322,7 +325,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - regenerator-runtime@0.14.1
 
@@ -352,7 +355,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - reselect@4.1.8
 
@@ -382,7 +385,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - tr46@0.0.3
 
@@ -392,7 +395,7 @@ This package contains the following license and notice below:
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - ulidx@2.2.1
 
@@ -422,7 +425,7 @@ SOFTWARE.
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - webidl-conversions@3.0.1
 
@@ -443,7 +446,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----------
 
-The following NPM package may be included in this product:
+The following npm package may be included in this product:
 
  - whatwg-url@5.0.0
 
@@ -473,4 +476,5 @@ THE SOFTWARE.
 
 -----------
 
-This file was generated with generate-license-file! https://www.npmjs.com/package/generate-license-file
+This file was generated with the generate-license-file npm package!
+https://www.npmjs.com/package/generate-license-file

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -1,9 +1,6 @@
-This file was generated with the generate-license-file npm package!
-https://www.npmjs.com/package/generate-license-file
+The following NPM package may be included in this product:
 
-The following npm package may be included in this product:
-
- - @babel/runtime@7.23.5
+ - @babel/runtime@7.23.6
 
 This package contains the following license and notice below:
 
@@ -32,7 +29,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @reduxjs/toolkit@1.9.7
 
@@ -62,7 +59,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @yext/analytics@0.6.5
 
@@ -103,7 +100,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - @yext/chat-core@0.7.0
 
@@ -145,7 +142,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - cross-fetch@3.1.8
 
@@ -175,7 +172,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - immer@9.0.21
 
@@ -205,7 +202,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - layerr@2.0.1
 
@@ -235,7 +232,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - node-fetch@2.7.0
 
@@ -265,7 +262,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - redux-thunk@2.4.2
 
@@ -295,7 +292,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - redux@4.2.1
 
@@ -325,9 +322,9 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
- - regenerator-runtime@0.14.0
+ - regenerator-runtime@0.14.1
 
 This package contains the following license and notice below:
 
@@ -355,7 +352,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - reselect@4.1.8
 
@@ -385,7 +382,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - tr46@0.0.3
 
@@ -395,7 +392,7 @@ This package contains the following license and notice below:
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - ulidx@2.2.1
 
@@ -425,7 +422,7 @@ SOFTWARE.
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - webidl-conversions@3.0.1
 
@@ -446,7 +443,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 -----------
 
-The following npm package may be included in this product:
+The following NPM package may be included in this product:
 
  - whatwg-url@5.0.0
 
@@ -476,5 +473,4 @@ THE SOFTWARE.
 
 -----------
 
-This file was generated with the generate-license-file npm package!
-https://www.npmjs.com/package/generate-license-file
+This file was generated with generate-license-file! https://www.npmjs.com/package/generate-license-file

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "A state manager library powered by Redux for Yext Chat integrations",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",

--- a/packages/chat-headless/src/ChatHeadlessImpl.ts
+++ b/packages/chat-headless/src/ChatHeadlessImpl.ts
@@ -10,13 +10,13 @@ import { State } from "./models/state";
 import { ReduxStateManager } from "./ReduxStateManager";
 import {
   loadSessionState,
+  saveSessionState,
   setCanSendMessage,
   setConversationId,
   setIsLoading,
   setMessageNotes,
   setMessages,
   addMessage,
-  STATE_SESSION_STORAGE_KEY,
 } from "./slices/conversation";
 import { DeepPartial, Store, Unsubscribe } from "@reduxjs/toolkit";
 import { StateListener } from "./models";
@@ -102,15 +102,12 @@ export class ChatHeadlessImpl implements ChatHeadless {
   initSessionStorage() {
     this.setState({
       ...this.state,
-      conversation: loadSessionState(),
+      conversation: loadSessionState(this.config.botId),
     });
     this.addListener({
       valueAccessor: (s) => s.conversation,
       callback: () =>
-        sessionStorage.setItem(
-          STATE_SESSION_STORAGE_KEY,
-          JSON.stringify(this.state.conversation)
-        ),
+        saveSessionState(this.config.botId, this.state.conversation),
     });
   }
 
@@ -170,7 +167,7 @@ export class ChatHeadlessImpl implements ChatHeadless {
   setChatLoadingStatus(isLoading: boolean) {
     this.stateManager.dispatch(setIsLoading(isLoading));
   }
-  
+
   setCanSendMessage(canSendMessage: boolean) {
     this.stateManager.dispatch(setCanSendMessage(canSendMessage));
   }

--- a/packages/chat-headless/src/slices/conversation.ts
+++ b/packages/chat-headless/src/slices/conversation.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { ConversationState } from "../models/slices/ConversationState";
 import { Message, MessageNotes } from "@yext/chat-core";
 
-export const STATE_SESSION_STORAGE_KEY = "yext_chat_conversation_state";
+const BASE_STATE_SESSION_STORAGE_KEY = "yext_chat_state";
 
 export const initialState: ConversationState = {
   messages: [],
@@ -10,18 +10,54 @@ export const initialState: ConversationState = {
   canSendMessage: true,
 };
 
+export function getStateSessionStorageKey(
+  hostname: string,
+  botId: string
+): string {
+  return `${BASE_STATE_SESSION_STORAGE_KEY}__${hostname}__${botId}`;
+}
+
 /**
  * Loads the {@link ConversationState} from session storage.
  */
-export const loadSessionState = (): ConversationState => {
+export const loadSessionState = (botId: string): ConversationState => {
   if (!sessionStorage) {
     console.warn(
       "Session storage is not available. State will not be persisted across page refreshes."
     );
     return initialState;
   }
-  const savedState = sessionStorage.getItem(STATE_SESSION_STORAGE_KEY);
+  const hostname = window?.location?.hostname;
+  if (!hostname) {
+    console.warn(
+      "Unable to get hostname of current page. State will not be persisted across page refreshes."
+    );
+    return initialState;
+  }
+  const savedState = sessionStorage.getItem(
+    getStateSessionStorageKey(hostname, botId)
+  );
   return savedState ? JSON.parse(savedState) : initialState;
+};
+
+export const saveSessionState = (botId: string, state: ConversationState) => {
+  if (!sessionStorage) {
+    console.warn(
+      "Session storage is not available. State will not be persisted across page refreshes."
+    );
+    return initialState;
+  }
+  const hostname = window?.location?.hostname;
+  if (!hostname) {
+    console.warn(
+      "Unable to get hostname of current page. State will not be persisted across page refreshes."
+    );
+    return initialState;
+  }
+  sessionStorage.setItem(
+    getStateSessionStorageKey(hostname, botId),
+    JSON.stringify(state)
+  );
 };
 
 /**

--- a/packages/chat-headless/tests/chatheadless.test.ts
+++ b/packages/chat-headless/tests/chatheadless.test.ts
@@ -11,14 +11,15 @@ import {
 import coreLib from "@yext/chat-core";
 import { ReduxStateManager } from "../src/ReduxStateManager";
 import {
+  getStateSessionStorageKey,
   initialState,
-  STATE_SESSION_STORAGE_KEY,
 } from "../src/slices/conversation";
 
 const config: HeadlessConfig = {
   botId: "MY_BOT",
   apiKey: "MY_API_KEY",
 };
+const jestHostname = "localhost";
 
 const mockedMetaState: MetaState = {
   context: {
@@ -287,7 +288,7 @@ describe("loadSessionState works as expected", () => {
   };
   it("loads valid state from session storage", () => {
     sessionStorage.setItem(
-      STATE_SESSION_STORAGE_KEY,
+      getStateSessionStorageKey(jestHostname, config.botId),
       JSON.stringify(expectedState)
     );
     const chatHeadless = provideChatHeadless(config);
@@ -299,7 +300,7 @@ describe("loadSessionState works as expected", () => {
 
   it("does not persist or load state when toggle is off", () => {
     sessionStorage.setItem(
-      STATE_SESSION_STORAGE_KEY,
+      getStateSessionStorageKey(jestHostname, config.botId),
       JSON.stringify(expectedState)
     );
     const chatHeadless = provideChatHeadless({
@@ -319,8 +320,10 @@ describe("loadSessionState works as expected", () => {
       },
     ];
     chatHeadless.setMessages(modifiedMessages);
-    expect(sessionStorage.getItem(STATE_SESSION_STORAGE_KEY)).toEqual(
-      JSON.stringify(expectedState)
-    );
+    expect(
+      sessionStorage.getItem(
+        getStateSessionStorageKey(jestHostname, config.botId)
+      )
+    ).toEqual(JSON.stringify(expectedState));
   });
 });


### PR DESCRIPTION
Update storage key for session storage to include current page's hostname and botId.

J=CLIP-897
TEST=manual

see that it works as expected in localhost
<img width="805" alt="Screenshot 2023-12-20 at 10 53 04 AM" src="https://github.com/yext/chat-headless/assets/36055303/e7054670-c57c-4faf-8d3b-9e37a30d4a84">
