### PR TITLE
export internal function/type

### DIFF
--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @babel/runtime@7.23.6
+ - @babel/runtime@7.23.9
 
 This package contains the following license and notice below:
 
@@ -67,7 +67,7 @@ The following npm packages may be included in this product:
  - @types/hoist-non-react-statics@3.3.5
  - @types/prop-types@15.7.11
  - @types/react-dom@18.2.18
- - @types/react@18.2.45
+ - @types/react@18.2.55
  - @types/scheduler@0.16.8
  - @types/use-sync-external-store@0.0.3
 
@@ -140,8 +140,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following npm packages may be included in this product:
 
- - @yext/chat-core@0.7.5
- - @yext/chat-headless@0.7.2
+ - @yext/chat-core@0.7.6
+ - @yext/chat-headless@0.7.3
 
 These packages each contain the following license and notice below:
 
@@ -595,7 +595,7 @@ This package contains the following license and notice below:
 
 The following npm package may be included in this product:
 
- - ulidx@2.2.1
+ - ulidx@2.3.0
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @babel/runtime@7.23.6
+ - @babel/runtime@7.23.9
 
 This package contains the following license and notice below:
 
@@ -397,7 +397,7 @@ This package contains the following license and notice below:
 
 The following npm package may be included in this product:
 
- - ulidx@2.2.1
+ - ulidx@2.3.0
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless/etc/chat-headless.api.md
+++ b/packages/chat-headless/etc/chat-headless.api.md
@@ -6,11 +6,13 @@
 
 import { ChatAnalyticsConfig } from '@yext/analytics';
 import { ChatConfig } from '@yext/chat-core';
+import { ChatCore } from '@yext/chat-core';
 import { ChatEventPayLoad } from '@yext/analytics';
 import { DeepPartial } from '@reduxjs/toolkit';
 import { EndEvent } from '@yext/chat-core';
 import { Endpoints } from '@yext/chat-core';
 import { Environment } from '@yext/chat-core';
+import { InternalConfig } from '@yext/chat-core';
 import { Message } from '@yext/chat-core';
 import { MessageNotes } from '@yext/chat-core';
 import { MessageRequest } from '@yext/chat-core';
@@ -34,6 +36,8 @@ export interface ChatClient {
 }
 
 export { ChatConfig }
+
+export { ChatCore }
 
 // @public
 export interface ChatHeadless {
@@ -80,6 +84,8 @@ export interface HeadlessConfig extends ChatConfig {
     saveToSessionStorage?: boolean;
 }
 
+export { InternalConfig }
+
 export { Message }
 
 export { MessageNotes }
@@ -97,6 +103,11 @@ export interface MetaState {
 
 // @public
 export function provideChatHeadless(config: HeadlessConfig): ChatHeadless;
+
+// Warning: (ae-internal-missing-underscore) The name "provideChatHeadlessInternal" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function provideChatHeadlessInternal(config: HeadlessConfig, internalConfig: InternalConfig): ChatHeadless;
 
 export { RawResponse }
 

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "A state manager library powered by Redux for Yext Chat integrations",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",

--- a/packages/chat-headless/src/corereexports.ts
+++ b/packages/chat-headless/src/corereexports.ts
@@ -16,4 +16,6 @@ export {
   Environment,
   Region,
   Endpoints,
+  InternalConfig,
+  ChatCore
 } from "@yext/chat-core";

--- a/packages/chat-headless/src/index.ts
+++ b/packages/chat-headless/src/index.ts
@@ -1,3 +1,3 @@
-export { provideChatHeadless } from "./HeadlessProvider";
+export { provideChatHeadless, provideChatHeadlessInternal } from "./HeadlessProvider";
 export * from "./models";
 export * from "./corereexports";


### PR DESCRIPTION
Export `provideChatHeadlessInternal` and `InternalConfig` in ChatHeadless to be accessible in Storm. This matches with the internal exports we already do for ChatHeadlessReact.

J=CLIP-977
TEST=none