### PR TITLE
ChatHeadless: incorporate ApiError from chat-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4880,6 +4880,14 @@
         "ulidx": "^2.0.0"
       }
     },
+    "node_modules/@yext/chat-core": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.8.0.tgz",
+      "integrity": "sha512-LTm/i3YLBLSebkQ8rxqlPRyiTNvcqLiIQEjhU8n9pSp2IZVpgqCm6dH6fJ67XZ1L1OZFjF6TeKpV1qpkuzhj+g==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
     "node_modules/@yext/chat-headless": {
       "resolved": "packages/chat-headless",
       "link": true
@@ -18700,12 +18708,12 @@
     },
     "packages/chat-headless": {
       "name": "@yext/chat-headless",
-      "version": "0.7.5",
+      "version": "0.8.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
         "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.7.0"
+        "@yext/chat-core": "^0.8.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.21.5",
@@ -19023,6 +19031,24 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
+      }
+    },
+    "packages/chat-headless-react/node_modules/@yext/chat-core": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.7.6.tgz",
+      "integrity": "sha512-rsZU4mVK6KtAwxTcABvyJIVatRfKPVk58xpFsyw7UoOUhBsT6Sz60WneVm/amvQV9qfCZrK8pljvsKuPaL7PSA==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5"
+      }
+    },
+    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.7.5.tgz",
+      "integrity": "sha512-MML3rncz0yilzNQTYYBk+sTw34BBs3TMJLznaXcpCwQtMu2raeaKPBbeKo+CiErzEy1RdnIkOZibYaIUQApsGA==",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.5",
+        "@yext/analytics": "^0.6.3",
+        "@yext/chat-core": "^0.7.0"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {
@@ -19984,14 +20010,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
-      }
-    },
-    "packages/chat-headless/node_modules/@yext/chat-core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-core/-/chat-core-0.7.0.tgz",
-      "integrity": "sha512-D7PLurAhi2vQKu5Wo96W9XYGqfUUKJORj6fCKPZJanmIM+2GXvTnKoBbtMycPDniacWH99ONUzV8Akj7ysGFTw==",
-      "dependencies": {
-        "cross-fetch": "^3.1.5"
       }
     },
     "packages/chat-headless/node_modules/ansi-styles": {

--- a/packages/chat-headless/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless/THIRD-PARTY-NOTICES
@@ -3,7 +3,7 @@ https://www.npmjs.com/package/generate-license-file
 
 The following npm package may be included in this product:
 
- - @babel/runtime@7.23.9
+ - @babel/runtime@7.24.5
 
 This package contains the following license and notice below:
 
@@ -64,7 +64,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - @yext/analytics@0.6.5
+ - @yext/analytics@0.6.6
 
 This package contains the following license and notice below:
 
@@ -105,7 +105,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following npm package may be included in this product:
 
- - @yext/chat-core@0.7.0
+ - @yext/chat-core@0.8.0
 
 This package contains the following license and notice below:
 
@@ -207,7 +207,7 @@ SOFTWARE.
 
 The following npm package may be included in this product:
 
- - layerr@2.0.1
+ - layerr@2.1.0
 
 This package contains the following license and notice below:
 

--- a/packages/chat-headless/docs/chat-headless.chatheadless.getnextmessage.md
+++ b/packages/chat-headless/docs/chat-headless.chatheadless.getnextmessage.md
@@ -27,5 +27,5 @@ a Promise of a response from the Chat API
 
 ## Remarks
 
-If rejected, an Error is returned.
+If rejected, an ApiError is returned. A new message is added to the conversation history only if the provided text is not empty.
 

--- a/packages/chat-headless/docs/chat-headless.chatheadless.streamnextmessage.md
+++ b/packages/chat-headless/docs/chat-headless.chatheadless.streamnextmessage.md
@@ -27,5 +27,5 @@ a Promise of the full response from the Chat Stream API
 
 ## Remarks
 
-If rejected, an Error is returned.
+If rejected, an ApiError is returned. A new message is added to the conversation history only if the provided text is not empty.
 

--- a/packages/chat-headless/etc/chat-headless.api.md
+++ b/packages/chat-headless/etc/chat-headless.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ApiError } from '@yext/chat-core';
 import { ChatAnalyticsConfig } from '@yext/analytics';
 import { ChatConfig } from '@yext/chat-core';
 import { ChatEventPayLoad } from '@yext/analytics';
@@ -28,6 +29,8 @@ import { StreamEventName } from '@yext/chat-core';
 import { StreamResponse } from '@yext/chat-core';
 import { TokenStreamEvent } from '@yext/chat-core';
 import { Unsubscribe } from '@reduxjs/toolkit';
+
+export { ApiError }
 
 // @public
 export interface ChatClient {

--- a/packages/chat-headless/package.json
+++ b/packages/chat-headless/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless",
-  "version": "0.7.5",
+  "version": "0.8.0",
   "description": "A state manager library powered by Redux for Yext Chat integrations",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",
@@ -40,7 +40,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
     "@yext/analytics": "^0.6.3",
-    "@yext/chat-core": "^0.7.0"
+    "@yext/chat-core": "^0.8.0"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.21.5",

--- a/packages/chat-headless/src/ChatHeadlessImpl.ts
+++ b/packages/chat-headless/src/ChatHeadlessImpl.ts
@@ -5,6 +5,7 @@ import {
   MessageResponse,
   MessageSource,
   StreamEventName,
+  ApiError,
 } from "@yext/chat-core";
 import { State } from "./models/state";
 import { ReduxStateManager } from "./ReduxStateManager";
@@ -258,7 +259,9 @@ export class ChatHeadlessImpl implements ChatHeadless {
         await stream.consume();
         if (!messageResponse) {
           return Promise.reject(
-            "Stream Error: Missing full message response at the end of stream."
+            new ApiError(
+              "Stream Error: Missing full message response at the end of stream."
+            )
           );
         }
         return messageResponse;
@@ -311,7 +314,7 @@ export class ChatHeadlessImpl implements ChatHeadless {
     } catch (e) {
       this.setCanSendMessage(true);
       this.setChatLoadingStatus(false);
-      return Promise.reject(e as Error);
+      return Promise.reject(e);
     }
     this.report({
       action: "CHAT_RESPONSE",

--- a/packages/chat-headless/src/corereexports.ts
+++ b/packages/chat-headless/src/corereexports.ts
@@ -17,5 +17,6 @@ export {
   Region,
   Endpoints,
   InternalConfig,
-  ChatPrompt
+  ChatPrompt,
+  ApiError,
 } from "@yext/chat-core";

--- a/packages/chat-headless/src/index.ts
+++ b/packages/chat-headless/src/index.ts
@@ -1,3 +1,6 @@
-export { provideChatHeadless, provideChatHeadlessInternal } from "./HeadlessProvider";
+export {
+  provideChatHeadless,
+  provideChatHeadlessInternal,
+} from "./HeadlessProvider";
 export * from "./models";
 export * from "./corereexports";

--- a/packages/chat-headless/src/models/ChatHeadless.ts
+++ b/packages/chat-headless/src/models/ChatHeadless.ts
@@ -137,7 +137,8 @@ export interface ChatHeadless {
    * @public
    *
    * @remarks
-   * If rejected, an Error is returned.
+   * If rejected, an ApiError is returned.
+   * A new message is added to the conversation history only if the provided text is not empty.
    *
    * @param text - the text of the next message
    * @param source - the source of the message
@@ -168,7 +169,8 @@ export interface ChatHeadless {
    * @experimental
    *
    * @remarks
-   * If rejected, an Error is returned.
+   * If rejected, an ApiError is returned.
+   * A new message is added to the conversation history only if the provided text is not empty.
    *
    * @param text - the text of the next message
    * @param source - the source of the message

--- a/packages/chat-headless/tests/chatheadless.chatapi.test.ts
+++ b/packages/chat-headless/tests/chatheadless.chatapi.test.ts
@@ -10,6 +10,7 @@ import {
   MessageResponse,
   RawResponse,
   StreamResponse,
+  ApiError,
 } from "../src";
 import { initialState } from "../src/slices/conversation";
 import { Readable } from "stream";
@@ -203,13 +204,15 @@ describe("Chat API methods work as expected", () => {
     );
     mockChatCore(coreStreamNextMessageSpy);
     const chatHeadless = provideChatHeadless(config);
-    expect.assertions(2);
+    expect.assertions(3);
 
     try {
       await chatHeadless.streamNextMessage("This is a dummy text!");
     } catch (e) {
       // eslint-disable-next-line jest/no-conditional-expect
-      expect(e).toEqual(
+      expect(e).toBeInstanceOf(ApiError);
+      // eslint-disable-next-line jest/no-conditional-expect
+      expect(e.message).toEqual(
         "Stream Error: Missing full message response at the end of stream."
       );
     }


### PR DESCRIPTION
bump chat-core version to v0.8.0 to get changes from https://github.com/yext/chat-core/pull/32

J=CLIP-1189
TEST=manual&auto

see that unit tests passed
build chat-headless and link the library locally to chat-ui-react. Force an internal error using yen-bot-2 (v18)'s CHIT_CHAT goal. See that the thrown error is instance of ApiError and contains the expected new fields.