### PR TITLE
Headless-React: incorporate ApiError from chat-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18732,11 +18732,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.7.1",
+        "@yext/chat-headless": "^0.8.0",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -19039,16 +19039,6 @@
       "integrity": "sha512-rsZU4mVK6KtAwxTcABvyJIVatRfKPVk58xpFsyw7UoOUhBsT6Sz60WneVm/amvQV9qfCZrK8pljvsKuPaL7PSA==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
-      }
-    },
-    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.7.5.tgz",
-      "integrity": "sha512-MML3rncz0yilzNQTYYBk+sTw34BBs3TMJLznaXcpCwQtMu2raeaKPBbeKo+CiErzEy1RdnIkOZibYaIUQApsGA==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.7.0"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -139,8 +139,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following npm packages may be included in this product:
 
- - @yext/chat-core@0.7.6
- - @yext/chat-headless@0.7.5
+ - @yext/chat-core@0.8.0
+ - @yext/chat-headless@0.8.0
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.7.1",
+    "@yext/chat-headless": "^0.8.0",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
bump chat-headless version to v0.8.0 to get changes from https://github.com/yext/chat-headless/pull/46

J=CLIP-1189
TEST=manual&auto

see that unit tests passed
build chat-headless-react and link the library locally to chat-ui-react. Force an internal error using yen-bot-2 (v18)'s CHIT_CHAT goal. See that the thrown error is instance of ApiError and contains the expected new fields.