### PR TITLE
headless-react: update Provider to use saveTolocalStorage prop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18746,11 +18746,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.8.0",
+        "@yext/chat-headless": "^0.9.0",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -19045,16 +19045,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
-      }
-    },
-    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.8.0.tgz",
-      "integrity": "sha512-2KSrIpnkMOvC8anQJ/VkYhH1VNeOA4Zka5h+HU0STXldtLZ3hKSlSufd/87qR+ie1M3xgcrlZHGBHX8fB2FOyw==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.8.0"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -140,7 +140,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following npm packages may be included in this product:
 
  - @yext/chat-core@0.8.0
- - @yext/chat-headless@0.8.0
+ - @yext/chat-headless@0.9.0
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.8.0",
+    "@yext/chat-headless": "^0.9.0",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -31,14 +31,16 @@ export function ChatHeadlessProvider(
   const { children, config } = props;
 
   const headless = useMemo(() => {
-    const configWithoutSession = { ...config, saveToSessionStorage: false };
-    const headless = provideChatHeadless(updateClientSdk(configWithoutSession));
+    const configWithoutLocalStorage = { ...config, saveToLocalStorage: false };
+    const headless = provideChatHeadless(
+      updateClientSdk(configWithoutLocalStorage)
+    );
     return headless;
   }, [config]);
 
   return (
     <ChatHeadlessInstanceProvider
-      deferRender={config.saveToSessionStorage}
+      deferRender={config.saveToLocalStorage}
       headless={headless}
     >
       {children}
@@ -53,7 +55,7 @@ export function ChatHeadlessProvider(
  */
 export type ChatHeadlessInstanceProviderProps = PropsWithChildren<{
   // Set this to true when using server-side rendering in conjunction with
-  // browser-specific APIs like session storage.
+  // browser-specific APIs like local storage.
   deferRender?: boolean;
   headless: ChatHeadless;
 }>;
@@ -69,19 +71,19 @@ export function ChatHeadlessInstanceProvider(
   props: ChatHeadlessInstanceProviderProps
 ): JSX.Element {
   const { children, deferRender, headless } = props;
-  // deferLoad is typically used with sessionStorage so that the children won't be
+  // deferLoad is typically used with localStorage so that the children won't be
   // immediately rendered and trigger the "load initial message" flow before
-  // the state can be loaded from session.
+  // the state can be loaded from local storage.
   const [deferLoad, setDeferLoad] = useState(deferRender);
 
-  // sessionStorage is overridden here so that it is compatible with server-
-  // side rendering, which cannot have browser api calls like session storage
+  // localStorage is overridden here so that it is compatible with server-
+  // side rendering, which cannot have browser api calls like local storage
   // outside of hooks.
   useEffect(() => {
     if (!deferRender || !headless) {
       return;
     }
-    headless.initSessionStorage();
+    headless.initLocalStorage();
     setDeferLoad(false);
   }, [headless, deferRender]);
 

--- a/packages/chat-headless-react/tests/headlessProvider.test.tsx
+++ b/packages/chat-headless-react/tests/headlessProvider.test.tsx
@@ -7,14 +7,20 @@ import {
 import { renderToString } from "react-dom/server";
 import { useChatState } from "../src/useChatState";
 
-it("only fetches session storage on client-side render", async () => {
+it("only fetches local storage on client-side render", async () => {
   const win = window;
-  Object.defineProperty(win, "sessionStorage", {
+  Object.defineProperty(win, "localStorage", {
     value: {
-      ...win.sessionStorage,
+      ...win.localStorage,
       getItem: (_: string): string => {
         return JSON.stringify({
-          messages: [{ text: "foobar", source: "BOT" }],
+          messages: [
+            {
+              text: "foobar",
+              source: "BOT",
+              timestamp: new Date().toISOString(),
+            },
+          ],
           isLoading: false,
           canSendMessage: false,
         } satisfies ConversationState);
@@ -27,7 +33,7 @@ it("only fetches session storage on client-side render", async () => {
   const config: HeadlessConfig = {
     botId: "123",
     apiKey: "1234",
-    saveToSessionStorage: true,
+    saveToLocalStorage: true,
   };
   const str = () =>
     renderToString(


### PR DESCRIPTION
updates following this breaking change in headless: https://github.com/yext/chat-headless/pull/49

J=CLIP-1292
TEST=auto&manual

see that unit tests passed. spun up test site and see that convo state persist across tabs.