### PR TITLE
chat-headless-react: Support clients param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18746,11 +18746,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.9.0",
+        "@yext/chat-headless": "^0.10.0",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -19045,16 +19045,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
-      }
-    },
-    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.9.0.tgz",
-      "integrity": "sha512-fwtmXoyVV30+xlTxjIxFAd+gmMNLGsnpoGT6OZMxG5v0kKJIvLHn9Ss8c0jXr/c+T/yG9i3fbWzV9i0usT6k9Q==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.8.0"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -139,8 +139,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The following npm packages may be included in this product:
 
- - @yext/chat-core@0.8.0
- - @yext/chat-headless@0.9.0
+ - @yext/chat-core@0.8.2
+ - @yext/chat-headless@0.10.0
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/docs/chat-headless-react.chatheadlessproviderprops.md
+++ b/packages/chat-headless-react/docs/chat-headless-react.chatheadlessproviderprops.md
@@ -11,5 +11,9 @@ Props for [ChatHeadlessProvider()](./chat-headless-react.chatheadlessprovider.md
 ```typescript
 export type ChatHeadlessProviderProps = PropsWithChildren<{
     config: HeadlessConfig;
+    clients?: {
+        bot?: ChatClient;
+        agent?: ChatClient;
+    };
 }>;
 ```

--- a/packages/chat-headless-react/etc/chat-headless-react.api.md
+++ b/packages/chat-headless-react/etc/chat-headless-react.api.md
@@ -6,6 +6,7 @@
 
 /// <reference types="react" />
 
+import { ChatClient } from '@yext/chat-headless';
 import { ChatHeadless } from '@yext/chat-headless';
 import { Context } from 'react';
 import { HeadlessConfig } from '@yext/chat-headless';
@@ -34,6 +35,10 @@ export function ChatHeadlessProvider(props: ChatHeadlessProviderProps): JSX.Elem
 // @public
 export type ChatHeadlessProviderProps = PropsWithChildren<{
     config: HeadlessConfig;
+    clients?: {
+        bot?: ChatClient;
+        agent?: ChatClient;
+    };
 }>;
 
 // @public

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.9.0",
+    "@yext/chat-headless": "^0.10.0",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {

--- a/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
+++ b/packages/chat-headless-react/src/ChatHeadlessProvider.tsx
@@ -2,6 +2,7 @@ import {
   provideChatHeadless,
   ChatHeadless,
   HeadlessConfig,
+  ChatClient,
 } from "@yext/chat-headless";
 import React, { PropsWithChildren, useMemo, useEffect, useState } from "react";
 import { Provider } from "react-redux";
@@ -15,6 +16,13 @@ import { updateClientSdk } from "./utils/clientSdk";
  */
 export type ChatHeadlessProviderProps = PropsWithChildren<{
   config: HeadlessConfig;
+  /**
+   * Optional clients to provide to the ChatHeadless instance.
+   */
+  clients?: {
+    bot?: ChatClient;
+    agent?: ChatClient;
+  };
 }>;
 
 /**
@@ -28,15 +36,16 @@ export type ChatHeadlessProviderProps = PropsWithChildren<{
 export function ChatHeadlessProvider(
   props: ChatHeadlessProviderProps
 ): JSX.Element {
-  const { children, config } = props;
+  const { children, config, clients } = props;
 
   const headless = useMemo(() => {
     const configWithoutLocalStorage = { ...config, saveToLocalStorage: false };
     const headless = provideChatHeadless(
-      updateClientSdk(configWithoutLocalStorage)
+      updateClientSdk(configWithoutLocalStorage),
+      clients
     );
     return headless;
-  }, [config]);
+  }, [config, clients]);
 
   return (
     <ChatHeadlessInstanceProvider


### PR DESCRIPTION
bump headless version for this feature: https://github.com/yext/chat-headless/pull/51
update ChatHeadlessProvider to accepts `clients` param as a passthrough to headless

J=CLIP-1328
TEST=manual

tested through test-site with chat-core-aws-connect as agent client