### PR TITLE
chat-headless-react: bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18746,11 +18746,11 @@
     },
     "packages/chat-headless-react": {
       "name": "@yext/chat-headless-react",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@reduxjs/toolkit": "^1.9.5",
-        "@yext/chat-headless": "^0.10.0",
+        "@yext/chat-headless": "^0.10.1",
         "react-redux": "^8.0.5"
       },
       "devDependencies": {
@@ -19045,16 +19045,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
-      }
-    },
-    "packages/chat-headless-react/node_modules/@yext/chat-headless": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@yext/chat-headless/-/chat-headless-0.10.0.tgz",
-      "integrity": "sha512-rYabLNfU8KcMDw/HqAkWbFuu2AavSjEtU5kYYAVdTRcS3LyrsNXe/l7lp11R3RCmJCcJnn5TXqhcTKzfI8I9zA==",
-      "dependencies": {
-        "@reduxjs/toolkit": "^1.9.5",
-        "@yext/analytics": "^0.6.3",
-        "@yext/chat-core": "^0.8.2"
       }
     },
     "packages/chat-headless-react/node_modules/ansi-styles": {

--- a/packages/chat-headless-react/THIRD-PARTY-NOTICES
+++ b/packages/chat-headless-react/THIRD-PARTY-NOTICES
@@ -140,7 +140,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The following npm packages may be included in this product:
 
  - @yext/chat-core@0.8.2
- - @yext/chat-headless@0.10.0
+ - @yext/chat-headless@0.10.1
 
 These packages each contain the following license and notice below:
 

--- a/packages/chat-headless-react/package.json
+++ b/packages/chat-headless-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yext/chat-headless-react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "the official React UI Bindings layer for Chat Headless",
   "main": "./dist/commonjs/src/index.js",
   "module": "./dist/esm/src/index.mjs",
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/yext/chat-headless#readme",
   "dependencies": {
     "@reduxjs/toolkit": "^1.9.5",
-    "@yext/chat-headless": "^0.10.0",
+    "@yext/chat-headless": "^0.10.1",
     "react-redux": "^8.0.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
Bumps the version to include the new session reset bug fix from chat-headless.

TEST=compile